### PR TITLE
fix case sensitive filename issue for linux users

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1,5 +1,5 @@
 const vscode		= require('vscode');
-const TreeviewPanel	= require('./TreeviewPanel');
+const TreeviewPanel	= require('./treeviewPanel');
 
 function activate(context) {
 	const treeviewPanel = new TreeviewPanel(context);


### PR DESCRIPTION
Linux file paths are case sensitive. This error causes Better Open Editors not to work at all on Linux. This PR fixes that issue. 