### PR TITLE
fix: viewType undefined

### DIFF
--- a/src/treeviewPanel.js
+++ b/src/treeviewPanel.js
@@ -108,6 +108,8 @@ class TreeviewPanel {
 		let tabs = vscode.window.tabGroups.all.map(group => group.tabs).flat();
 
 		tabs = tabs.filter(tab => {
+			if (!tab.input) return false;
+
 			// keep images
 			if (tab.input.viewType === 'imagePreview.previewEditor') return true;
 


### PR DESCRIPTION
some tabs(like Welcome Page) will have their input attribute undefined
I've met this bug too
#20 